### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,27 +88,20 @@ For each queue in each vhost the following statistics are gathered:
 > NOTE: The ```/``` vhost name is sent as ```default```
 
 * message_stats
+    * ack
+    * ack_rate
+    * deliver
     * deliver_get
-    * deliver_get_details 
-    	* rate 
-    * get
-    * get_details
-        * rate
-    * publish
-    * publish_details
-        * rate
-    * redeliver  
-    * redeliver_details
-        * rate
+    * deliver_get_rate
+    * deliver_rate
+    * redeliver
+    * redeliver_rate
 * messages
-* messages_details 
-    * rate
+* messages_rate
 * messages_ready
-* messages_ready_details
-    * rate
+* messages_ready_rate
 * messages_unacknowledged
-* messages_unacknowledged_details
-  * rate
+* messages_unacknowledged_rate
 * memory
 * consumers
 
@@ -118,30 +111,11 @@ Exchanges
 For each exchange in each vhost the following statistics are gathered: 
 > NOTE: The ```/``` vhost name is sent as ```default```
 
-* disk_free 
-
-* disk_free_limit 
-
-* fd_total
-
-* fd_used
-
-* mem_limit 
-
-* mem_used
-
-* proc_total
-
-* proc_used 
-
-* processors
-
-* run_queue
-
-* sockets_total
-
-* sockets_used
-
+* message_stats
+    * publish_in
+    * publish_in_rate
+    * publish_out
+    * publish_out_rate
 
 Developing
 ==========

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -11,25 +11,25 @@ run_queue       value:GAUGE:0:U
 sockets_total   value:GAUGE:0:U
 sockets_used    value:GAUGE:0:U
 
-rabbitmq_consumers						value:GAUGE:0:U
-rabbitmq_memory							value:GAUGE:0:U
-rabbitmq_messages						value:GAUGE:0:U
-rabbitmq_messages_rate					value:GAUGE:0:U
-rabbitmq_messages_ready					value:GAUGE:0:U
-rabbitmq_messages_ready_rate			value:GAUGE:0:U
-rabbitmq_messages_unacknowledged		value:GAUGE:0:U
+rabbitmq_consumers			value:GAUGE:0:U
+rabbitmq_memory				value:GAUGE:0:U
+rabbitmq_messages			value:GAUGE:0:U
+rabbitmq_messages_rate			value:GAUGE:0:U
+rabbitmq_messages_ready			value:GAUGE:0:U
+rabbitmq_messages_ready_rate		value:GAUGE:0:U
+rabbitmq_messages_unacknowledged	value:GAUGE:0:U
 rabbitmq_messages_unacknowledged_rate	value:GAUGE:0:U
 
-ack					value:GAUGE:0:U
-ack_rate			value:GAUGE:0:U
-deliver				value:GAUGE:0:U
-deliver_get			value:GAUGE:0:U
+ack			value:GAUGE:0:U
+ack_rate		value:GAUGE:0:U
+deliver			value:GAUGE:0:U
+deliver_get		value:GAUGE:0:U
 deliver_get_rate	value:GAUGE:0:U
 deliver_rate		value:GAUGE:0:U
-publish_in			value:GAUGE:0:U
+publish_in		value:GAUGE:0:U
 publish_in_rate		value:GAUGE:0:U
-publish_out			value:GAUGE:0:U
+publish_out		value:GAUGE:0:U
 publish_out_rate	value:GAUGE:0:U
-redeliver			value:GAUGE:0:U
+redeliver		value:GAUGE:0:U
 redeliver_rate		value:GAUGE:0:U
 

--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -11,22 +11,25 @@ run_queue       value:GAUGE:0:U
 sockets_total   value:GAUGE:0:U
 sockets_used    value:GAUGE:0:U
 
-rabbitmq_memory value:GAUGE:0:U
-rabbitmq_messages value:GAUGE:0:U
-rabbitmq_messages_ready value:GAUGE:0:U
-rabbitmq_messages_unacknowledged value:GAUGE:0:U
-rabbitmq_consumers value:GAUGE:0:U
-rabbitmq_details avg:GAUGE:0:U avg_rate:GAUGE:0:U rate:GAUGE:0:U samples:GAUGE:0:U
+rabbitmq_consumers						value:GAUGE:0:U
+rabbitmq_memory							value:GAUGE:0:U
+rabbitmq_messages						value:GAUGE:0:U
+rabbitmq_messages_rate					value:GAUGE:0:U
+rabbitmq_messages_ready					value:GAUGE:0:U
+rabbitmq_messages_ready_rate			value:GAUGE:0:U
+rabbitmq_messages_unacknowledged		value:GAUGE:0:U
+rabbitmq_messages_unacknowledged_rate	value:GAUGE:0:U
 
-ack           value:GAUGE:0:U
-publish       value:GAUGE:0:U
-publish_in    value:GAUGE:0:U
-publish_out   value:GAUGE:0:U
-confirm       value:GAUGE:0:U
-deliver       value:GAUGE:0:U
-deliver_noack value:GAUGE:0:U
-get           value:GAUGE:0:U
-get_noack     value:GAUGE:0:U
-deliver_get   value:GAUGE:0:U
-redeliver     value:GAUGE:0:U
-return        value:GAUGE:0:U
+ack					value:GAUGE:0:U
+ack_rate			value:GAUGE:0:U
+deliver				value:GAUGE:0:U
+deliver_get			value:GAUGE:0:U
+deliver_get_rate	value:GAUGE:0:U
+deliver_rate		value:GAUGE:0:U
+publish_in			value:GAUGE:0:U
+publish_in_rate		value:GAUGE:0:U
+publish_out			value:GAUGE:0:U
+publish_out_rate	value:GAUGE:0:U
+redeliver			value:GAUGE:0:U
+redeliver_rate		value:GAUGE:0:U
+

--- a/rabbitmq.py
+++ b/rabbitmq.py
@@ -9,13 +9,28 @@ import re
 
 RABBIT_API_URL = "http://{host}:{port}/api/"
 
-QUEUE_MESSAGE_STATS = ['messages', 'messages_ready', 'messages_unacknowledged']
-QUEUE_STATS = ['memory', 'messages', 'consumers']
+QUEUE_STATS = {
+   'consumers': { 'hasMsgStats' : False },
+   'memory': {'hasMsgStats': False },
+   'messages': { 'hasMsgStats': True },
+   'messages_ready': { 'hasMsgStats': True },
+   'messages_unacknowledged': { 'hasMsgStats': True }
+}
 
-MESSAGE_STATS = ['ack', 'publish', 'publish_in', 'publish_out', 'confirm',
-                 'deliver', 'deliver_noack', 'get', 'get_noack', 'deliver_get',
-                 'redeliver', 'return']
-MESSAGE_DETAIL = ['avg', 'avg_rate', 'rate', 'sample']
+MESSAGE_STATS = 'rate'
+
+QUEUE_MESSAGE_STATS = {
+   'ack': { 'hasMsgStats' : True },
+   'deliver': {'hasMsgStats': True },
+   'deliver_get': { 'hasMsgStats': True },
+   'redeliver': { 'hasMsgStats': True }
+}
+
+EXCHANGE_MESSAGE_STATS = {
+   'publish_in': { 'hasMsgStats' : True },
+   'publish_out': {'hasMsgStats': True }
+}
+
 NODE_STATS = ['disk_free', 'disk_free_limit', 'fd_total',
               'fd_used', 'mem_limit', 'mem_used',
               'proc_total', 'proc_used', 'processors', 'run_queue',
@@ -111,7 +126,7 @@ def dispatch_values(values, host, plugin, plugin_instance, metric_type,
     metric.dispatch()
 
 
-def dispatch_message_stats(data, vhost, plugin, plugin_instance):
+def dispatch_message_stats(data, vhost, plugin, plugin_instance, metrics):
     """
     Sends message stats to collectd.
     """
@@ -119,9 +134,16 @@ def dispatch_message_stats(data, vhost, plugin, plugin_instance):
         collectd.debug("No data for %s in vhost %s" % (plugin, vhost))
         return
 
-    for name in MESSAGE_STATS:
-        dispatch_values((data.get(name, 0),), vhost, plugin,
-                        plugin_instance, name)
+    for key, value in metrics.iteritems():
+        dispatch_values((data.get(key, 0),), vhost, plugin,
+                        plugin_instance, key)
+        if value['hasMsgStats']:
+            details = data.get("%s_details" % key, None)
+            if details is None:
+                continue
+            else:
+                dispatch_values((details.get(MESSAGE_STATS, 0),), vhost, plugin,
+                                plugin_instance, '%s_rate' % key)
 
 
 def dispatch_queue_metrics(queue, vhost):
@@ -130,25 +152,19 @@ def dispatch_queue_metrics(queue, vhost):
     '''
 
     vhost_name = 'rabbitmq_%s' % (vhost['name'].replace('/', 'default'))
-    for name in QUEUE_STATS:
-        values = list((queue.get(name, 0),))
-        dispatch_values(values, vhost_name, 'queues', queue['name'],
-                        'rabbitmq_%s' % name)
-
-    for name in QUEUE_MESSAGE_STATS:
-        values = list((queue.get(name, 0),))
-        dispatch_values(values, vhost_name, 'queues', queue['name'],
-                        'rabbitmq_%s' % name)
-
-        details = queue.get("%s_details" % name, None)
-        values = list()
-        for detail in MESSAGE_DETAIL:
-            values.append(details.get(detail, 0))
-        dispatch_values(values, vhost_name, 'queues', queue['name'],
-                        'rabbitmq_details', name)
+    for key, value in QUEUE_STATS.iteritems():
+        dispatch_values((queue.get(key, 0),), vhost_name, 'queues', queue['name'],
+                        'rabbitmq_%s' % key)
+        if value['hasMsgStats']:
+            details = queue.get("%s_details" % key, None)
+            if details is None:
+                continue
+            else:
+                dispatch_values((details.get(MESSAGE_STATS, 0),), vhost_name, 'queues', queue['name'],
+                               'rabbitmq_%s_rate' % key)
 
     dispatch_message_stats(queue.get('message_stats', None), vhost_name,
-                           'queues', queue['name'])
+                           'queues', queue['name'], QUEUE_MESSAGE_STATS)
 
 
 def dispatch_exchange_metrics(exchange, vhost):
@@ -157,7 +173,7 @@ def dispatch_exchange_metrics(exchange, vhost):
     '''
     vhost_name = 'rabbitmq_%s' % vhost['name'].replace('/', 'default')
     dispatch_message_stats(exchange.get('message_stats', None), vhost_name,
-                           'exchanges', exchange['name'])
+                           'exchanges', exchange['name'], EXCHANGE_MESSAGE_STATS)
 
 
 def dispatch_node_metrics(node):


### PR DESCRIPTION
"avg", "avg_rate", and, "samples" fields are no longer part of the
resulting JSON object produced by the RabbitMQ HTTP API of
"/api/queues/vhost/_queue_name_". This change will eliminate the
indexing of these metrics by collectd
